### PR TITLE
Add workflows to enable auto releases

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,8 @@
+"feature":
+  - head-branch: ["feature/*", "feat/*"]
+"fix":
+  - head-branch: ["fix/*", "bug/*"]
+"chore":
+  - head-branch: ["chore/*", "docs/*", "refactor/*"]
+"breaking-change":
+  - head-branch: ["breaking/*", "major/*"]

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,19 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+  - title: "🚀 Features"
+    labels: ["feature", "enhancement"]
+  - title: "🐛 Bug Fixes"
+    labels: ["bug", "fix"]
+  - title: "🧰 Maintenance"
+    labels: ["chore", "refactor"]
+change-template: "-- $TITLE by @$AUTHOR"
+version-resolver:
+  major:
+    labels: ["breaking-change"]
+  minor:
+    labels: ["feature", "enhancement"]
+  patch:
+    labels: ["bug", "fix", "chore", "refactor"]
+  default: patch
+prerelease-identifier: "alpha"

--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -1,0 +1,15 @@
+name: Auto Labeler
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+---
+name: Create GitHub Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 1"
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Release Drafter
+        uses: release-drafter/release-drafter@v6
+        with:
+          publish: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces several improvements to the GitHub Actions workflows and configuration files to automate labeling and release processes. The main changes include adding configurations for labeling pull requests based on branch names, setting up release drafter templates, and configuring workflows for auto-labeling and creating releases.

### Workflow and Configuration Improvements:

* [`.github/labeler.yml`](diffhunk://#diff-a22c263686553013feaeb0677d26eeb0b8778a756c4311c1fce13384258026aaR1-R8): Added configurations to label pull requests automatically based on branch name patterns.
* [`.github/release-drafter.yml`](diffhunk://#diff-101bec72d0f1f84e7290d113531bbd8c6aa355cdc9f456df255544bc0a2da0eaR1-R19): Added a release drafter configuration to automate the generation of release notes, including templates for version names, tags, and categorized changes.

### GitHub Actions Workflows:

* [`.github/workflows/auto-labeler.yml`](diffhunk://#diff-f874b1d773361dc46f2496bc3ce97ee3441e91257188b27a2bd83693c3b8a82eR1-R15): Created a workflow to automatically label pull requests using the `actions/labeler` GitHub Action.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R1-R26): Created a workflow to automate the creation of GitHub releases using the `release-drafter` GitHub Action, triggered by pushes to the main branch and on a weekly schedule.