### PR TITLE
Prettier release template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -7,7 +7,7 @@ categories:
     labels: ["bug", "fix"]
   - title: "🧰 Maintenance"
     labels: ["chore", "refactor"]
-change-template: "-- [$NUMBER]($URL) $TITLE by @$AUTHOR"
+change-template: "-- [#[$NUMBER]($URL)] $TITLE by @$AUTHOR"
 version-resolver:
   major:
     labels: ["breaking-change"]


### PR DESCRIPTION
This pull request includes a minor change to the `.github/release-drafter.yml` file. The change modifies the `change-template` to ensure proper formatting of issue numbers.

* [`.github/release-drafter.yml`](diffhunk://#diff-101bec72d0f1f84e7290d113531bbd8c6aa355cdc9f456df255544bc0a2da0eaL10-R10): Updated `change-template` to include brackets around the issue number for proper formatting.