### PR TITLE
minor documentation changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,3 @@ pull-spec:
 
 gen-spec: pull-spec
 	go generate tools/tools.go
-
-gen-spec-2: pull-spec
-	openapi-generator generate -i .out/spec.json -g go -o client --skip-validate-spec

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Statsig Go Client
-This is a Go client for the Statsig API. It is code-generated from the OpenAPI spec and intended for use primarily in the [useless-solutions/terraform-provider-statsig](https://github.com/useless-solutions/terraform-provider-statsig).
+This is a Go client for the Statsig API. It is code-generated from the official OpenAPI spec and intended for use primarily in the [useless-solutions/terraform-provider-statsig](https://github.com/useless-solutions/terraform-provider-statsig) project.
 
-The repository is managed by [@httpoz](https://github.com/httpoz) and [@tamirarnesty](https://github.com/tamirarnesty)
+The repository is managed by [@httpoz](https://github.com/httpoz) and [@tamirarnesty](https://github.com/tamirarnesty).


### PR DESCRIPTION
This pull request includes a few changes to the `Makefile` and `README.md` files to clean up unused targets and improve documentation. 

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2-R4): Updated the description to specify that the Go client is generated from the official OpenAPI spec and added a missing period at the end of the repository managers' sentence.

Code cleanup:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L7-L9): Removed the unused `gen-spec-2` target to clean up the file.