### PR TITLE
Correct module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nonsense-solutions/statsig-go-client
+module github.com/useless-solutions/statsig-go-client
 
 go 1.22.5
 


### PR DESCRIPTION
This pull request includes a small change to the `go.mod` file. The change updates the module path to reflect a new organization name.

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L1-R1): Changed module path from `github.com/nonsense-solutions/statsig-go-client` to `github.com/useless-solutions/statsig-go-client`.