### PR TITLE
Split releaser and labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,8 @@
+feature:
+  - head-branch: ["feature"]
+fix:
+  - head-branch: ["fix"]
+chore:
+  - head-branch: ["chore"]
+breaking-change:
+  - head-branch: ["breaking"]

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,40 +2,22 @@ name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 categories:
   - title: "🚀 Features"
-    labels: ["feature", "enhancement"]
+    labels: ["feature"]
   - title: "🐛 Bug Fixes"
-    labels: ["bug", "fix"]
+    labels: ["fix"]
   - title: "🧰 Maintenance"
-    labels: ["chore", "refactor"]
+    labels: ["chore"]
 change-template: "-- [#[$NUMBER]($URL)] $TITLE by @$AUTHOR"
 version-resolver:
   major:
     labels: ["breaking-change"]
   minor:
-    labels: ["feature", "enhancement"]
+    labels: ["feature"]
   patch:
-    labels: ["bug", "fix", "chore", "refactor"]
+    labels: ["fix", "chore"]
   default: patch
 prerelease-identifier: "alpha"
 template: |
   ## Changes
 
   $CHANGES
-autolabeler:
-  - label: "feature"
-    branch:
-      - feature/*
-      - feat/*
-  - label: "fix"
-    branch:
-      - fix/*
-      - bug/*
-  - label: "chore"
-    branch:
-      - chore/*
-      - docs/*
-      - refactor/*
-  - label: "breaking-change"
-    branch:
-      - breaking/*
-      - major/*

--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -1,0 +1,14 @@
+name: Pull Request Labeler
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 ---
 name: Create GitHub Release
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
   push:
@@ -8,10 +11,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * 1"
-  # pull_request event is required only for autolabeler
-  pull_request:
-    # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request includes several changes to improve the automation of labeling and releasing processes in the GitHub repository. The main changes involve configuring labelers for pull requests, updating the release drafter configuration, and modifying the release workflow.

### Labeling Configuration:

* [`.github/labeler.yml`](diffhunk://#diff-a22c263686553013feaeb0677d26eeb0b8778a756c4311c1fce13384258026aaR1-R8): Added configurations to automatically label pull requests based on the branch name.
* [`.github/workflows/auto-labeler.yml`](diffhunk://#diff-f874b1d773361dc46f2496bc3ce97ee3441e91257188b27a2bd83693c3b8a82eR1-R14): Introduced a new workflow to label pull requests using the `actions/labeler` GitHub Action.

### Release Drafter Configuration:

* [`.github/release-drafter.yml`](diffhunk://#diff-101bec72d0f1f84e7290d113531bbd8c6aa355cdc9f456df255544bc0a2da0eaL5-L41): Updated the release drafter configuration to align labels with the new labeling system, removing redundant labels and autolabeler configurations.

### Release Workflow:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R3-R5): Added concurrency control to the release workflow to cancel in-progress runs if a new run is triggered.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L11-L14): Removed the `pull_request` event trigger from the release workflow, as it is no longer needed for the autolabeler.