### PR TITLE
Set prerelease tag to pick up existing drafts

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,7 +8,7 @@ categories:
     labels: ["fix"]
   - title: "🧰 Maintenance"
     labels: ["chore"]
-change-template: "-- [#[$NUMBER]($URL)] $TITLE by @$AUTHOR"
+change-template: "-- [[#$NUMBER]($URL)] $TITLE by @$AUTHOR"
 version-resolver:
   major:
     labels: ["breaking-change"]

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,6 @@
 name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
+prerelease: true
 categories:
   - title: "🚀 Features"
     labels: ["feature"]


### PR DESCRIPTION
This pull request includes a small change to the `.github/release-drafter.yml` file. The change sets the `prerelease` attribute to `true`.

* [`.github/release-drafter.yml`](diffhunk://#diff-101bec72d0f1f84e7290d113531bbd8c6aa355cdc9f456df255544bc0a2da0eaR3): Added `prerelease: true` to the release drafter configuration.