### PR TITLE
split publish and draft release flows

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,29 @@
+name: Draft GitHub Release
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Release Drafter
+        uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,16 +1,10 @@
----
-name: Create GitHub Release
+name: Publish GitHub Release
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: true
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * 1"
 
 permissions:
   contents: read
@@ -29,5 +23,7 @@ jobs:
 
       - name: Run Release Drafter
         uses: release-drafter/release-drafter@v6
+        with:
+          publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes significant changes to the GitHub Actions workflows related to the release process. The main changes involve renaming and splitting the release workflows into two separate files: one for drafting releases and one for publishing releases.

Changes to release workflows:

* `.github/workflows/release.yml` was renamed to `.github/workflows/draft-release.yml`, and the workflow name was updated to "Draft GitHub Release".
* The `workflow_dispatch` and `schedule` triggers were removed from the `.github/workflows/draft-release.yml` file.
* A new workflow file `.github/workflows/publish-release.yml` was created to handle publishing GitHub releases. This includes setting up concurrency, permissions, and defining the `update_release_draft` job with steps to checkout code and run the Release Drafter action.