### PR TITLE
move prerelease flag to action

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,5 @@
 name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
-prerelease: true
 categories:
   - title: "🚀 Features"
     labels: ["feature"]

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -25,5 +25,7 @@ jobs:
 
       - name: Run Release Drafter
         uses: release-drafter/release-drafter@v6
+        with:
+          prerelease: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -25,5 +25,6 @@ jobs:
         uses: release-drafter/release-drafter@v6
         with:
           publish: true
+          prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes changes to the release drafter configuration and workflows to manage prerelease settings more effectively.

Changes to `.github/release-drafter.yml`:

* Removed the `prerelease: true` setting to allow for more flexible prerelease management in workflows.

Changes to workflows:

* [`.github/workflows/draft-release.yml`](diffhunk://#diff-3d80a0bd2aa867253847d98ff0fddb8982d61587bee3ddfb9906f4aafbe55329R28-R29): Added `prerelease: true` to the `Run Release Drafter` step to mark draft releases as prereleases.
* [`.github/workflows/publish-release.yml`](diffhunk://#diff-232ead425069ad86b523a739aa18b77f9088cd61a4b40c6a374d9774ff78cfc8R28): Added `prerelease: false` to the `Run Release Drafter` step to ensure published releases are not marked as prereleases.