### PR TITLE
Update permissions for calling centralised actions

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   call-draft-release:
     uses: useless-solutions/.github/.github/workflows/release-draft.yml@main

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,6 +3,10 @@ name: Publish GitHub Release
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   call-publish-release:
     uses: useless-solutions/.github/.github/workflows/release-publish.yml@main


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to ensure proper permissions for writing contents and pull requests.

Changes to GitHub Actions workflows:

* [`.github/workflows/draft-release.yml`](diffhunk://#diff-3d80a0bd2aa867253847d98ff0fddb8982d61587bee3ddfb9906f4aafbe55329R8-R11): Added permissions for writing contents and pull requests to the workflow configuration.
* [`.github/workflows/publish-release.yml`](diffhunk://#diff-232ead425069ad86b523a739aa18b77f9088cd61a4b40c6a374d9774ff78cfc8R6-R9): Added permissions for writing contents and pull requests to the workflow configuration.